### PR TITLE
feat: add orderBy and desc + asc functionality

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,15 +1,24 @@
-from flask import Blueprint, Flask, render_template, request, redirect
-from sqlalchemy import select
+from flask import Blueprint, Flask, render_template, session, request, redirect
+from sqlalchemy import select, desc, asc
 
 from database import db, DATABASE_URI
 from models.todo import Todo
 
 root_blueprint = Blueprint("root", __name__)
 
-
+# http://localhost:5000/todos?orderBy=completed&desc=1
 @root_blueprint.route("/")
 def index():
-    todos = db.session.execute(select(Todo)).scalars()
+    # check if session has order_by param
+    print(session)
+    if 'orderBy' in session:
+        # query with order by
+        if 'desc' in session and session['desc']:
+            todos = db.session.execute(select(Todo).order_by(desc(session['orderBy']))).scalars()
+        else:
+            todos = db.session.execute(select(Todo).order_by(asc(session['orderBy']))).scalars()
+    else:
+        todos = db.session.execute(select(Todo)).scalars()
     return render_template("index.html", todos=todos)
 
 
@@ -42,11 +51,25 @@ def delete(todo_id):
     db.session.commit()
     return redirect("/")
 
+'''
+feature we will add is the ability for the user to change the order of todos
+1.  Drop down allowing user to select what to order by
+2. API handler that takes in order_by and returns tasks by specified order
+/todos/?order_by="completed | title"
+'''
+@root_blueprint.get("/todos")
+def order_by():
+    order_by = request.args.get('orderBy')
+    descending_order = request.args.get('desc')
+    session['orderBy'] = order_by
+    session['desc'] = True if descending_order == '1' else False
+    return redirect("/")
+
 
 def initialize_app():
     app = Flask(__name__)
-
     app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
+    app.secret_key = 'TEST'
 
     db.init_app(app)
 
@@ -56,7 +79,6 @@ def initialize_app():
         db.create_all()
 
     return app
-
 
 if __name__ == "__main__":
     initialize_app().run(debug=True)


### PR DESCRIPTION
High Level Summary:
Users can order their todo list by any attribute of the database (i.e. title or completed status)

- example endpoint: `/todos?orderBy=completed&desc=1`

**How**

- added ability to store session data
- added new endpoint /todos
- takes in query parameters such as "orderBy" and "desc" and stores it in the session
- index page checks for session attributes and executes db query based on the orderBy and desc status

